### PR TITLE
Add more comprehensive unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ matrix:
 install:
   - pip install --upgrade pip
   - pip install -r requirements.txt
-script: pytest test.py
+script: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure the project root is on the Python path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+from click.testing import CliRunner
+from bulk_directory_tree import main
+import os
+
+
+def test_cli_creates_directories(tmp_path):
+    runner = CliRunner()
+    root = tmp_path / "root"
+    result = runner.invoke(main, ["-p", str(root), "-n", "2", "-d", "2", "-l", "4"])
+    assert result.exit_code == 0
+    first_level = [p for p in root.iterdir() if p.is_dir()]
+    assert len(first_level) == 2
+    for d in first_level:
+        second_level = [p for p in d.iterdir() if p.is_dir()]
+        assert len(second_level) == 2
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import pytest
 from bulk_directory_tree import main
 
 
-def test_main():
+def test_main_direct_call_raises():
     with pytest.raises(TypeError):
-        main(9,'f','u','c')
+        main(9, 'f', 'u', 'c')
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import bulk_directory_tree as bdt
+
+
+def test_get_randname_length():
+    bdt.dirname_length = 8
+    name = bdt.get_randname()
+    assert len(name) == 8
+
+
+def test_gen_names_structure():
+    bdt.num_of_dir = 2
+    bdt.dig_depth = 3
+    bdt.dirname_length = 4
+    names = bdt.gen_names()
+    assert len(names) == 3
+    for i, level in enumerate(names, start=1):
+        assert len(level) == 2 ** i
+


### PR DESCRIPTION
## Summary
- rework tests into a dedicated `tests` package
- add CLI and utility tests for directory creation and helper functions
- ensure test suite runs via Travis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684857c1002c8329bd55177bfefa0ffe